### PR TITLE
Make @types/parse5 a regular dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-<!-- ## Unreleased -->
+## Unreleased
+- Fix missing `@types/parse5` dependency for TypeScript users.
 <!-- Add new unreleased items here -->
 
 ## [1.0.0-pre.2] - 2019-06-05

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "@types/koa": "^2.0.48",
     "@types/koa-route": "^3.2.4",
     "@types/node": "^12.0.2",
-    "@types/parse5": "^5.0.0",
     "@types/path-is-inside": "^1.0.0",
     "@types/resolve": "0.0.8",
     "@types/supertest": "^2.0.7",
@@ -57,6 +56,7 @@
     "@babel/generator": "^7.4.4",
     "@babel/parser": "^7.4.5",
     "@babel/traverse": "^7.4.5",
+    "@types/parse5": "^5.0.0",
     "get-stream": "^5.1.0",
     "parse5": "^5.1.0",
     "resolve": "^1.11.0"


### PR DESCRIPTION
Because the public API uses that type, so it won't compile for TypeScript users unless they happen to also have that dependency.