### PR TITLE
Allow logger: false

### DIFF
--- a/src/koa-node-resolve.ts
+++ b/src/koa-node-resolve.ts
@@ -22,8 +22,10 @@ import {resolveNodeSpecifier} from './support/resolve-node-specifier';
 
 export {Logger} from './support/logger';
 
-export type NodeResolveOptions =
-    ModuleSpecifierTransformOptions&{root?: string, logger?: false | Logger};
+export type NodeResolveOptions = Pick<
+    ModuleSpecifierTransformOptions,
+    Exclude<keyof ModuleSpecifierTransformOptions, 'logger'>>&
+    {root?: string, logger?: false | Logger};
 
 /**
 /**


### PR DESCRIPTION
The previous type signature didn't actually `logger: false`, since you can't broaden a type with an intersection. Have to remove the old property first.