### PR TITLE
Correct/simplify logger option typings.

### DIFF
--- a/src/koa-module-specifier-transform.ts
+++ b/src/koa-module-specifier-transform.ts
@@ -40,7 +40,7 @@ export type SpecifierTransform = (baseURL: string, specifier: string) =>
     string|undefined;
 
 export type ModuleSpecifierTransformOptions = {
-  logger?: Logger,
+  logger?: Logger|false,
   htmlParser?: HTMLParser,
   htmlSerializer?: HTMLSerializer,
   jsParser?: JSParser,
@@ -65,7 +65,7 @@ export const moduleSpecifierTransform = (specifierTransform: SpecifierTransform,
                                          options:
                                              ModuleSpecifierTransformOptions =
                                                  {}): Koa.Middleware => {
-  const logger = options.logger || console;
+  const logger = options.logger === false ? {} : (options.logger || console);
   const htmlParser = options.htmlParser || defaultHTMLParser;
   const htmlSerializer = options.htmlSerializer || defaultHTMLSerializer;
   const jsParser = options.jsParser || defaultJSParser;

--- a/src/koa-node-resolve.ts
+++ b/src/koa-node-resolve.ts
@@ -16,14 +16,14 @@ import {resolve as resolvePath} from 'path';
 import {parse as parseURL} from 'url';
 
 import {moduleSpecifierTransform, ModuleSpecifierTransformOptions} from './koa-module-specifier-transform';
-import {Logger, prefixLogger} from './support/logger';
+import {prefixLogger} from './support/logger';
 import {noLeadingSlash} from './support/path-utils';
 import {resolveNodeSpecifier} from './support/resolve-node-specifier';
 
 export {Logger} from './support/logger';
 
 export type NodeResolveOptions =
-    ModuleSpecifierTransformOptions&{root?: string, logger?: false | Logger};
+    ModuleSpecifierTransformOptions&{root?: string};
 
 /**
 /**


### PR DESCRIPTION
I accidentally defined the addition of `false` to the logger option typing in `koa-node-resolve.ts` as opposed to `koa-module-specifier-transform.ts` where it belonged.  This PR fixes that.