### PR TITLE
Updated CHANGELOG and package.json for release of 1.0.0-pre.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-## Unreleased
-- Fix missing `@types/parse5` dependency for TypeScript users.
+<!-- ## Unreleased -->
 <!-- Add new unreleased items here -->
 
 ## [1.0.0-pre.3] - 2019-06-06
+- Fix missing `@types/parse5` dependency for TypeScript users.
 - Fix invalid TypeScript typings related to the logger option.
 
 ## [1.0.0-pre.2] - 2019-06-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- ## Unreleased -->
 <!-- Add new unreleased items here -->
 
+## [1.0.0-pre.3] - 2019-06-06
+- Fix invalid TypeScript typings related to the logger option.
+
 ## [1.0.0-pre.2] - 2019-06-05
 - Rewrites resolvable Node package specifiers in JavaScript module files.
 - Rewrites resolvable Node package specifiers in HTML files in `<script type="module">` elements, honoring `<base href>` where present.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-node-resolve",
-  "version": "1.0.0-pre.2",
+  "version": "1.0.0-pre.3",
   "description": "",
   "main": "lib/koa-node-resolve.js",
   "files": [


### PR DESCRIPTION
- [ ] koa-node-resolve@1.0.0-pre.3

Fixed TypeScript typings for logger option.