### PR TITLE
Better babel plugin defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-<!-- ## Unreleased -->
+## Unreleased
+- Added `dynamicImport`, `importMeta`, `exportDefaultFrom` and `exportNamespaceFrom` to default Babel parser configuration.
+- Added single-quoted strings, `retainFunctionParens` and `retainLines` to default Babel generator configuration.
 <!-- Add new unreleased items here -->
 
 ## [1.0.0-pre.3] - 2019-06-06

--- a/src/koa-module-specifier-transform.ts
+++ b/src/koa-module-specifier-transform.ts
@@ -56,10 +56,36 @@ const defaultHTMLSerializer = (ast: Parse5Node): string => {
 };
 
 const defaultJSParser = (js: string): BabelNode =>
-    babelParse(js, {sourceType: 'unambiguous'}) as BabelNode;
+    babelParse(js, {
+      sourceType: 'unambiguous',
+      allowAwaitOutsideFunction: true,
+      plugins: [
+        'dynamicImport',
+        'exportDefaultFrom',
+        'exportNamespaceFrom',
+        'importMeta',
+      ],
+    }) as BabelNode;
+
+// TODO(usergenic): Send PR to update `@types/babel__generator`
+declare module '@babel/generator' {
+  interface GeneratorOptions {
+    jsescOption: {
+      quotes: 'single'|'double',
+    };
+    retainFunctionParens: Boolean;
+  }
+}
 
 const defaultJSSerializer = (ast: BabelNode): string =>
-    babelSerialize(ast).code;
+    babelSerialize(ast, {
+      concise: false,
+      jsescOption: {
+        quotes: 'single',
+      },
+      retainFunctionParens: true,
+      retainLines: true,
+    }).code;
 
 export const moduleSpecifierTransform = (specifierTransform: SpecifierTransform,
                                          options:

--- a/src/test/koa-node-resolve.test.ts
+++ b/src/test/koa-node-resolve.test.ts
@@ -40,14 +40,14 @@ test('nodeResolve middleware transforms resolvable specifiers', async (t) => {
         t.equal(
             squeeze((await request(server).get('/my-module.js')).text),
             squeeze(`
-              import * as x from "./node_modules/x/main.js";
+              import * as x from './node_modules/x/main.js';
             `),
             'should transform specifiers in JavaScript module');
         t.equal(
             squeeze((await request(server).get('/my-page.html')).text),
             squeeze(`
               <script type="module">
-              import * as x from "./node_modules/x/main.js";
+              import * as x from './node_modules/x/main.js';
               </script>
             `),
             'should transform specifiers in inline module script');


### PR DESCRIPTION
I didn't have tests for dynamic imports even though the transform was built to support them.  Which also revealed I didn't support dynamic imports by default in the parser 🤦‍♂️ and so I added modern syntax feature defaults to the JS parser and threw in a couple better defaults to the default JS serializer.