### PR TITLE
Move @types/babel__generator to dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- Fix `Module '@babel/generator' resolves to an untyped module` error for TypeScript users.
 <!-- Add new unreleased items here -->
 
 ## [1.0.0-pre.4] - 2019-06-07

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
   "author": "The Polymer Project Authors",
   "devDependencies": {
     "@babel/types": "^7.4.4",
-    "@types/babel__generator": "^7.0.2",
     "@types/babel__traverse": "^7.0.6",
     "@types/get-stream": "^3.0.2",
     "@types/koa": "^2.0.48",
@@ -53,6 +52,7 @@
     "typescript": "^3.4.5"
   },
   "dependencies": {
+    "@types/babel__generator": "^7.0.2",
     "@babel/generator": "^7.4.4",
     "@babel/parser": "^7.4.5",
     "@babel/traverse": "^7.4.5",


### PR DESCRIPTION
This is because the module augmentation is included in the `.d.ts` file, which means consumers will get the tsc error:

```
node_modules/koa-node-resolve/lib/koa-module-specifier-transform.d.ts:23:16 - error TS2665: Invalid module name in augmentation. Module '@babel/generator' resolves to an untyped module at '/Users/aomarks/git/tachometer/node_modules/@babel/generator/lib/index.js', which cannot be augmented.

23 declare module '@babel/generator' {
                  ~~~~~~~~~~~~~~~~~~
```