### PR TITLE
Added tests for `resolve-node-specifier.ts` to ensure that relative path resolution works.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
       "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
-      "dev": true,
       "requires": {
         "@babel/types": "^7.0.0"
       }

--- a/src/test/resolve-node-specifier.test.ts
+++ b/src/test/resolve-node-specifier.test.ts
@@ -71,3 +71,35 @@ test('resolveNodeSpecifier resolves extension-less relative path', (t) => {
       './node_modules/z/binary-file.node',
       'should resolve to `.node` extension');
 });
+
+test('resolveNodeSpecifier resolves relative paths', (t) => {
+  t.plan(5);
+  t.equal(
+      resolve('./some-file.js'),
+      './some-file.js',
+      'should resolve relative path to non-package file');
+  t.equal(
+      resolve('./non-existing-file.js'),
+      './non-existing-file.js',
+      'should resolve a relative path specifier when the file does not exist');
+  t.equal(
+      resolve('./node_modules/x/main.js'),
+      './node_modules/x/main.js',
+      'should resolve relative path to existing main file');
+  t.equal(
+      resolve('./node_modules/y/main.js'),
+      './node_modules/y/main.js',
+      'should resolve relative path to existing jsnext:main file');
+  t.equal(
+      resolve('./node_modules/z/main.js'),
+      './node_modules/z/main.js',
+      'should resolve relative path to existing module file');
+});
+
+test('resolveNodeSpecifier resolves modules without import/export', (t) => {
+  t.plan(1);
+  t.equal(
+      resolve('no-imports-or-exports'),
+      './node_modules/no-imports-or-exports/main.js',
+      'should resolve package which contains non-module main.js');
+});

--- a/test/fixtures/node_modules/no-imports-or-exports/main.js
+++ b/test/fixtures/node_modules/no-imports-or-exports/main.js
@@ -1,0 +1,1 @@
+window.someGlobalThing('Important side effect!')

--- a/test/fixtures/node_modules/no-imports-or-exports/package.json
+++ b/test/fixtures/node_modules/no-imports-or-exports/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "no-imports-or-exports",
+  "version": "1.0.0",
+  "main": "main.js"
+}

--- a/test/fixtures/some-file.js
+++ b/test/fixtures/some-file.js
@@ -1,0 +1,1 @@
+console.log('Just some file.')


### PR DESCRIPTION
Wrote these tests to investigate https://github.com/Polymer/koa-node-resolve/issues/16

At least as far as in the test environment, this is working as intended.  Warnings are issued for relative paths that can't be resolved due to missing files only.