### PR TITLE
Updated package.json and CHANGELOG for release of 1.0.0-pre.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-## Unreleased
+<!-- ## Unreleased -->
+<!-- Add new unreleased items here -->
+
+## [1.0.0-pre.5] - 2019-06-25
 - Fixed issue where `nodeResolve()` did not properly effect the level of the provided `logger` where individual specifier transform logging was concerned.
 - Fix `Module '@babel/generator' resolves to an untyped module` error for TypeScript users.
 - Fix issue where html/head/body tags were stripped out by default parser/serializer.
-<!-- Add new unreleased items here -->
 
 ## [1.0.0-pre.4] - 2019-06-07
 - Added `logLevel` option which defaults to `warn` so info/debug transformations are supressed by default.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-node-resolve",
-  "version": "1.0.0-pre.4",
+  "version": "1.0.0-pre.5",
   "description": "",
   "main": "lib/koa-node-resolve.js",
   "files": [


### PR DESCRIPTION
- Fixed issue where `nodeResolve()` did not properly effect the level of the provided `logger` where individual specifier transform logging was concerned.
- Fix `Module '@babel/generator' resolves to an untyped module` error for TypeScript users.
- Fix issue where html/head/body tags were stripped out by default parser/serializer.