### PR TITLE
Fix bug where syntax errors would result in no response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
    Unreleased section, uncommenting the header as necessary.
 -->
 
-<!-- ## Unreleased -->
+## Unreleased
+- Fixed issue where syntax errors encountered in files would result in an empty response.
 <!-- Add new unreleased items here -->
 
 ## [1.0.0-pre.5] - 2019-06-25

--- a/src/koa-module-specifier-transform.ts
+++ b/src/koa-module-specifier-transform.ts
@@ -167,6 +167,10 @@ export const moduleSpecifierTransform =
               logger.error(
                   `Unable to transform module specifiers in "${url}" due to`,
                   error);
+          // We want errors to result in serving the unchanged original file. If
+          // body was a stream then we've already consumed it, so we need to
+          // assign the string copy here.
+          ctx.body = body;
         }
       };
     };

--- a/src/test/test-utils.ts
+++ b/src/test/test-utils.ts
@@ -14,6 +14,8 @@
 import {Server} from 'http';
 import Koa from 'koa';
 import route from 'koa-route';
+import {Readable} from 'stream';
+
 import {Logger} from '../support/logger';
 
 export type AppOptions = {
@@ -39,7 +41,12 @@ export const createApp = (options: AppOptions): Koa => {
         if (key.endsWith('.html')) {
           ctx.type = 'html';
         }
-        ctx.body = value;
+        // Make our body a stream, like koa static would do, to make sure we
+        // aren't, for example, consuming the body streams.
+        const stream = new Readable();
+        stream.push(value);
+        stream.push(null);
+        ctx.body = stream;
       }));
     }
   }


### PR DESCRIPTION
We had a test for this, but it didn't account for the case where the downstream body was a stream, in which case we were consuming it and never setting a new body.

Cause of https://github.com/Polymer/tachometer/issues/106