### PR TITLE
Enable builds on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "clean": "rimraf lib",
     "compile": "tsc",
     "depcheck": "depcheck --ignore-dirs=lib --ignores=\"rimraf,source-map-support,@types/*\"",
-    "format": "find src -name \"*.ts\" | xargs clang-format --style=file -i",
+    "format": "clang-format --style=file -i \"--glob=src/**/*.ts\"",
     "lint": "tslint -p . --fix",
     "test": "npm run test:raw --silent | tap-diff",
-    "test:raw": "tape -r source-map-support/register 'lib/test/*.test.js' 'lib/test/**/*.test.js'"
+    "test:raw": "tape -r source-map-support/register \"lib/test/*.test.js\" \"lib/test/**/*.test.js\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi 👋

I'm investigating Polymer/tachometer#137 which lead me to this module. I think I might need some fixes in this module to resolve that issue so starting off by getting the build working in Windows :)

Currently the tests don't pass on Windows mostly do to `/` vs `\\` so I hope just getting the tests passing might be good enough to fix the issue I'm seeing in Windows related to Polymer/tachometer#137. I'll fix the tests in a different PR since I suspect it'll be a bigger change.