### PR TITLE
Fix tests on Windows

### DIFF
--- a/src/koa-node-resolve.ts
+++ b/src/koa-node-resolve.ts
@@ -18,7 +18,7 @@ import {parse as parseURL} from 'url';
 import {moduleSpecifierTransform, ModuleSpecifierTransformOptions} from './koa-module-specifier-transform';
 import {prefixedLogger} from './support/logger';
 import {Logger} from './support/logger';
-import {noLeadingSlash} from './support/path-utils';
+import {noLeadingSlashInURL} from './support/path-utils';
 import {resolveNodeSpecifier} from './support/resolve-node-specifier';
 
 export {Logger} from './support/logger';
@@ -42,7 +42,7 @@ export const nodeResolve =
               resolveNodeSpecifier(
                   resolvePath(
                       resolvePath(options.root || '.'),
-                      noLeadingSlash(parseURL(baseURL).pathname || '/')),
+                      noLeadingSlashInURL(parseURL(baseURL).pathname || '/')),
                   specifier,
                   logger),
           Object.assign({}, options, {logger}));

--- a/src/support/path-utils.ts
+++ b/src/support/path-utils.ts
@@ -11,7 +11,9 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-import {relative} from 'path';
+import {posix, sep as pathSeparator} from 'path';
+
+const dirnameRegex = process.platform === 'win32' ? /[^\\]+$/ : /[^\/]+$/;
 
 /**
  * Similar to `path.dirname()` except includes trailing slash and for a
@@ -19,23 +21,23 @@ import {relative} from 'path';
  * trailing slash indicates `this` is a folder name not a file name.
  * (`path.dirname('/like/this/')` returns `/like`.)
  */
-export const dirname = (path: string): string => path.replace(/[^\/]+$/, '');
+export const dirname = (path: string): string => path.replace(dirnameRegex, '');
 
-export const ensureLeadingDot = (path: string): string =>
+export const ensureLeadingDotInURL = (path: string): string =>
     (path.startsWith('../') || path.startsWith('./')) ? path : './' + path;
 
-export const ensureTrailingSlash = (path: string): string =>
-    path.endsWith('/') ? path : path + '/';
+export const ensureTrailingSlashInPath = (path: string): string =>
+    path.endsWith(pathSeparator) ? path : path + pathSeparator;
 
 export const forwardSlashesOnlyPlease = (path: string): string =>
     path.replace(/\\/g, '/');
 
-export const getBasePath = (href: string): string =>
-    href.replace(/[^\/]+$/, '');
+export const getBaseUrl = (href: string): string => href.replace(/[^\/]+$/, '');
 
-export const noLeadingSlash = (href: string): string => href.replace(/^\//, '');
+export const noLeadingSlashInURL = (href: string): string =>
+    href.replace(/^\//, '');
 
-export const relativePath = (from: string, to: string): string =>
-    ensureLeadingDot(relative(
-        getBasePath(forwardSlashesOnlyPlease(from)),
+export const relativePathToUrl = (from: string, to: string): string =>
+    ensureLeadingDotInURL(posix.relative(
+        getBaseUrl(forwardSlashesOnlyPlease(from)),
         forwardSlashesOnlyPlease(to)));

--- a/src/support/resolve-node-specifier.ts
+++ b/src/support/resolve-node-specifier.ts
@@ -15,7 +15,7 @@ import nodeResolve from 'resolve';
 
 import {Logger} from './logger';
 
-import {dirname, relativePath} from './path-utils';
+import {dirname, relativePathToUrl} from './path-utils';
 
 export const resolveNodeSpecifier =
     (modulePath: string, specifier: string, logger: Logger): string => {
@@ -35,7 +35,7 @@ export const resolveNodeSpecifier =
                 packageJson.main
           })
         });
-        const resolvedURL = relativePath(modulePath, dependencyPath);
+        const resolvedURL = relativePathToUrl(modulePath, dependencyPath);
         if (resolvedURL !== specifier) {
           logger.debug &&
               logger.debug(`Resolved Node module specifier "${specifier}" to "${

--- a/src/test/resolve-node-specifier.test.ts
+++ b/src/test/resolve-node-specifier.test.ts
@@ -14,13 +14,13 @@
 import {resolve as resolvePath} from 'path';
 import test from 'tape';
 
-import {ensureTrailingSlash} from '../support/path-utils';
+import {ensureTrailingSlashInPath} from '../support/path-utils';
 import {resolveNodeSpecifier} from '../support/resolve-node-specifier';
 import {testLogger} from './test-utils';
 
 const logger = testLogger();
 const fixturesPath =
-    ensureTrailingSlash(resolvePath(__dirname, '../../test/fixtures/'));
+    ensureTrailingSlashInPath(resolvePath(__dirname, '../../test/fixtures/'));
 const resolve = (specifier: string): string =>
     resolveNodeSpecifier(fixturesPath, specifier, logger);
 


### PR DESCRIPTION
The `path-utils` file contains a mix of functions that operate on URL and OS paths. Since Windows paths use a different separator (sigh...) not all of these functions properly handled Windows paths.

To help understand which functions operate on URLs and which operate on OS paths, I renamed the functions in `path-utils` to include `URL` if they operate on URLs or `Path` if the operate on OS paths. Another approach could be to separate the functions into two files, `url-utils` and `os-path-utils` (or something similar). Or we could just leave the names as is and just update the relevant functions that need fixes. Let me know what you think! 😀 Happy to change however you'd prefer (VSCode's rename feature makes this pretty easy).

I'll leave a review that calls out the actual bug fixes.