### PR TITLE
Bump version of @types/babel__generator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -111,9 +111,9 @@
       }
     },
     "@types/babel__generator": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.0.2.tgz",
-      "integrity": "sha512-NHcOfab3Zw4q5sEE2COkpfXjoE7o+PmqD9DQW4koUT3roNxwziUdXGnRndMat/LJNUtePwn1TlP4do3uoe3KZQ==",
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+      "integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
       "requires": {
         "@babel/types": "^7.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "typescript": "^3.4.5"
   },
   "dependencies": {
-    "@types/babel__generator": "^7.0.2",
+    "@types/babel__generator": "^7.6.1",
     "@babel/generator": "^7.4.4",
     "@babel/parser": "^7.4.5",
     "@babel/traverse": "^7.4.5",

--- a/src/koa-module-specifier-transform.ts
+++ b/src/koa-module-specifier-transform.ts
@@ -69,16 +69,6 @@ const defaultJSParser = (js: string): BabelNode =>
       ],
     }) as BabelNode;
 
-// TODO(usergenic): Send PR to update `@types/babel__generator`
-declare module '@babel/generator' {
-  interface GeneratorOptions {
-    jsescOption: {
-      quotes: 'single'|'double',
-    };
-    retainFunctionParens: Boolean;
-  }
-}
-
 const defaultJSSerializer = (ast: BabelNode): string =>
     babelSerialize(ast, {
       concise: false,


### PR DESCRIPTION
A while back, the pinned version of `@types/babel__generator` diverged between `koa-node-resolve` and `tachometer`. This broke our ability to update the JSON schema in Tachometer. It seems as though the latest version of `@types/babel__generator` works fine in this package, and removes the need for the partial types previously written to patch-up missing types in the dependency.

The change https://github.com/Polymer/tachometer/pull/177 is currently blocked by a satisfying outcome to this version mismatch. To unblock the change, either the dependency version in Tachometer needs to be rolled back, or the dependency version here needs to be pulled forward.

It would be wonderful if the types could be updated here, and for a new version of `koa-node-resolve` to be published. 

Thanks in advance for your feedback and consideration.