### PR TITLE
Skip absolute path specifiers

### DIFF
--- a/src/support/resolve-node-specifier.ts
+++ b/src/support/resolve-node-specifier.ts
@@ -19,7 +19,7 @@ import {dirname, relativePathToURL} from './path-utils';
 
 export const resolveNodeSpecifier =
     (modulePath: string, specifier: string, logger: Logger): string => {
-      if (isURL(specifier)) {
+      if (isURL(specifier) || specifier.startsWith('/')) {
         return specifier;
       }
       try {


### PR DESCRIPTION
When passing a specifier such as `/module.js` to the `resolve`, `resolve` always tries to find the module at the root of the file system, not the root of the `basedir`. So I propose the node-resolve plugin skips absolute path specifiers since I think that trying to resolve for node_modules at the root of the file system is not very useful.

Since node-resolve will just pass along any specifiers it can't find, the only real behavior change that that I'm aware of is that node-resolve will no longer warn on absolute path specifiers when using the default logger.